### PR TITLE
Use gotgbot instead of telegram-bot-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,123 @@
 # Reddit Downloader Bot
 
-A telegram bot to download the reddit posts.
+A Telegram bot for downloading Reddit posts.
 
-## What can this bot do?
+Table of Contents
+=================
+  * [What this bot can do](#what-this-bot-can-do)
+  * [What this bot cannot do](#what-this-bot-cannot-do)
+    * [List of non x.redd.it hosts from which this bot *can* download](#list-of-non-xreddit-hosts-from-which-this-bot-can-download)
+  * [Setup](#setup)
+    * [Build](#build)
+    * [Obtain Reddit Token](#obtain-reddit-token)
+    * [Obtain Telegram Token](#obtain-telegram-token)
+    * [Run](#run)
+  * [Optional Settings](#optional-settings)
+    * [Allowed Users](#allowed-users)  
+    * [Disable NSFW Content](disable-nsfw-content)
 
-* Send posts as text in telegram
-* Download and send photos in `i.redd.it`
-* Download and send GIFs
-* Download videos on `v.redd.it` and merge the audio with them using [FFmpeg](https://www.ffmpeg.org/)
-* Download galleries
-* Choose the quality of photos or videos (except galleries, always the best resolution is used in them)
-* Download comments
-* Limit the users which can use it
+# What this bot can do
 
-## What this bot can't do?
+* Send Reddit posts and coments as text on Telegram
+* Send images and image galleries hosted on `i.redd.it`
+* Send videos hosted on `v.redd.it`
+* Convert videos to audio only
+* Send GIFs hosted on Reddit
+* Let users choose the quality of images and videos
+* Limit the users who can use it
 
-* Send deleted posts
+# What this bot cannot do
+
 * Send polls
-* Send text posts with more than 4096 characters or complex markdown (like tables)
-* Upload files that are larger than 50MB
-* Download any videos or photos that are not hosted on `x.redd.it` (for example youtube)
+* Send deleted posts
+* Upload files larger than 50 MB
+* Send text posts with over 4,096 characters or complex markdown (for example, tables)
+* Download images or videos that are not hosted on `x.redd.it` (for example, YouTube videos)
 
-### List of non `x.redd.it` hosts that this bot can download from them
+## List of non `x.redd.it` hosts from which this bot *can* download
 
-1. imgur (gifs and pictures)
-2. gfycat (Note that some of them may not work because they are not hosted on reddit. Also, they are soundless)
-3. streamable
-4. redgifs
+1. Imgur
+2. Gfycat
+3. Streamable
+4. Red GIFs (although currently not working)
 
-## Setup
+# Setup
 
-### Build
+## Build
 
-To start, please at first install [FFmpeg](https://www.ffmpeg.org/) in your path. On Ubuntu, `apt install ffmpeg` is
-enough.
-
-Then download and build this project:
+First, install [FFmpeg](https://www.ffmpeg.org). On Debian or Ubuntu, simply run `apt install ffmpeg`. Then, clone and build the project using the following steps.
 
 ```bash
-git clone https://github.com/HirbodBehnam/RedditDownloaderBot
+git clone https://github.com/mcsaeid/RedditDownloaderBot
 cd RedditDownloaderBot
 go build ./cmd/RedditDownloaderBot/
 ```
 
-### Reddit Token
+## Obtain Reddit Token
 
-To use this bot, you need to have a registered Reddit application. To do so, you can
-use [this](https://github.com/reddit-archive/reddit/wiki/OAuth2#getting-started) guide by Reddit itself.
-Choose `Script app` as application type. Doing so, will give you two tokens: A client id and a client secret. (The
-client id is the `one personal use script` text on top left)
+To use the bot, you will need Reddit and Telegram tokens. Start by creating a Reddit application. Go to https://www.reddit.com/prefs/apps and click on “are you a developer? create an app...” Choose a name, select `script` as the type of application, input something in the redirect URI field, and click on “create app.”
 
-### Running
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/63400670/215763728-f4242f17-46bd-421b-ab1c-493d1ec49f3b.png" alt="Creating a Reddit application"/>
+</p>
 
-For running, you have to set the environmental variables like this:
+You will be given two tokens: a client ID and a client secret—as shown in the image below.
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/63400670/215763740-7e4e771e-1c40-47a8-95fb-3227dd130a82.png" alt="Reddit tokens"/>
+</p>
+
+## Obtain Telegram Token
+
+Interact with [BotFather](https://t.me/BotFather) to create a bot and obtain its token. Additionally, you can use this [guide](https://core.telegram.org/bots/tutorial#obtain-your-bot-token).
+
+Your token will look something like this:
 
 ```bash
-export CLIENT_ID=p-jcoLKBynTLew
-export CLIENT_SECRET=gko_LXELoV07ZBNUXrvWZfzE3aI
-export BOT_TOKEN=1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy
-./RedditDownloaderBot
+4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc
 ```
 
-#### Docker
+## Run
 
-If you want, you can run this bot using docker compose. To do so, edit `docker-compose.yml` and change the environment
-variables needed for bot. Then use `docker compose up` to run the bot.
-
-#### Optional Settings
-
-##### Allowed Users
-
-You can configure the bot to allow only a certain users to access it. This is useful for deploying private bots.
-To do so, you need the user ids of the accounts which you want to whitelist. You can get the user id
-from [@myidbot](https://t.me/myidbot).
-After create an environment variable called `ALLOWED_USERS` and set its value to comma seperated user ids. For example:
+Now that you have the necessary tokens, edit the docker-compose.yml file and set the environment variables as such:
 
 ```bash
-export ALLOWED_USERS=1,2,3
+CLIENT_ID: "Reddit client ID"
+CLIENT_SECRET: "Reddit client secret"
+BOT_TOKEN: "Telegram bot token"
 ```
 
-##### Disable NSFW
-
-You can forbid the bot to download NSFW posts. To do so, set this environment variable:
+You can run the bot using docker-compose. In case you don’t have docker-compose installed, follow the steps below.
 
 ```bash
-export DENY_NSFW=true
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-##### Disable Link to Post
+Lastly, run `docker-compose up --build` inside the RedditDownloaderBot directory to build and run the bot.
 
-You can disable the link to posts which is automatically added to each message by setting this:
+# Optional Settings
+
+## Allowed Users
+
+You can configure the bot to allow access to only a group of users. This is useful for deploying private bots. To do so, you need to create a whitelist that consists of Telegram user IDs. You can obtain user IDs using [GetIDs Bot](https://t.me/getidsbot). Next, create the environment variable `ALLOWED_USERS` and set its value to user IDs, separated by a comma.
 
 ```bash
-export DISABLE_LINK_IN_CAPTION=true
+ALLOWED_USERS: "1,2,3"
+```
+
+## Disable NSFW Content
+
+You can keep the bot from downloading NSFW posts by setting the following environment variable:
+
+```bash
+DENY_NSFW: "true"
+```
+
+## Disable Post Link
+
+The post link is included in the caption by default. You can disable it by setting the following environment variable:
+
+```bash
+DISABLE_LINK_IN_CAPTION: "true"
 ```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Table of Contents
     * [Run](#run)
   * [Optional Settings](#optional-settings)
     * [Allowed Users](#allowed-users)  
-    * [Disable NSFW Content](disable-nsfw-content)
+    * [Disable NSFW Content](#disable-nsfw-content)
 
 # What this bot can do
 
-* Send Reddit posts and coments as text on Telegram
+* Send Reddit posts and comments as text on Telegram
 * Send images and image galleries hosted on `i.redd.it`
 * Send videos hosted on `v.redd.it`
 * Convert videos to audio only
@@ -48,7 +48,7 @@ Table of Contents
 First, install [FFmpeg](https://www.ffmpeg.org). On Debian or Ubuntu, simply run `apt install ffmpeg`. Then, clone and build the project using the following steps.
 
 ```bash
-git clone https://github.com/mcsaeid/RedditDownloaderBot
+git clone https://github.com/HirbodBehnam/RedditDownloaderBot
 cd RedditDownloaderBot
 go build ./cmd/RedditDownloaderBot/
 ```
@@ -82,9 +82,9 @@ Your token will look something like this:
 Now that you have the necessary tokens, edit the docker-compose.yml file and set the environment variables as such:
 
 ```bash
-CLIENT_ID: "Reddit client ID"
-CLIENT_SECRET: "Reddit client secret"
-BOT_TOKEN: "Telegram bot token"
+export CLIENT_ID=p-jcoLKBynTLew
+export CLIENT_SECRET=gko_LXELoV07ZBNUXrvWZfzE3aI
+export BOT_TOKEN=1234567:4TT8bAc8GHUspu3ERYn-KGcvsvGB9u_n4ddy
 ```
 
 You can run the bot using docker-compose. In case you don’t have docker-compose installed, follow the steps below.
@@ -103,7 +103,7 @@ Lastly, run `docker-compose up --build` inside the RedditDownloaderBot directory
 You can configure the bot to allow access to only a group of users. This is useful for deploying private bots. To do so, you need to create a whitelist that consists of Telegram user IDs. You can obtain user IDs using [GetIDs Bot](https://t.me/getidsbot). Next, create the environment variable `ALLOWED_USERS` and set its value to user IDs, separated by a comma.
 
 ```bash
-ALLOWED_USERS: "1,2,3"
+export ALLOWED_USERS=1,2,3
 ```
 
 ## Disable NSFW Content
@@ -111,7 +111,7 @@ ALLOWED_USERS: "1,2,3"
 You can keep the bot from downloading NSFW posts by setting the following environment variable:
 
 ```bash
-DENY_NSFW: "true"
+export DENY_NSFW=true
 ```
 
 ## Disable Post Link
@@ -119,5 +119,5 @@ DENY_NSFW: "true"
 The post link is included in the caption by default. You can disable it by setting the following environment variable:
 
 ```bash
-DISABLE_LINK_IN_CAPTION: "true"
+export DISABLE_LINK_IN_CAPTION=true
 ```

--- a/cmd/RedditDownloaderBot/main.go
+++ b/cmd/RedditDownloaderBot/main.go
@@ -53,14 +53,14 @@ func main() {
 }
 
 // getAllowedUsers gets the list of users which are allowed to use the bot
-func getAllowedUsers() (allowedIDs []int64) {
+func getAllowedUsers() []int64 {
 	usersString := strings.Split(os.Getenv("ALLOWED_USERS"), ",")
-	allowedIDs = make([]int64, 0, len(usersString))
+	allowedIDs := make([]int64, 0, len(usersString))
 	for _, idString := range usersString {
 		id, err := strconv.ParseInt(idString, 10, 64)
 		if err == nil {
 			allowedIDs = append(allowedIDs, id)
 		}
 	}
-	return
+	return allowedIDs
 }

--- a/cmd/RedditDownloaderBot/main.go
+++ b/cmd/RedditDownloaderBot/main.go
@@ -28,6 +28,7 @@ func main() {
 	if clientID == "" || clientSecret == "" || botToken == "" {
 		log.Fatalln("Please set CLIENT_ID, CLIENT_SECRET and BOT_TOKEN")
 	}
+	botClient := bot.Client{}
 	// Start up database
 	if redisAddress, redisPort := os.Getenv("REDIS_ADDRESS"), os.Getenv("REDIS_PORT"); redisAddress != "" && redisPort != "" {
 		// Parse ttl
@@ -35,20 +36,20 @@ func main() {
 		if ttl <= 0 {
 			ttl = 5 * time.Minute
 		}
-		bot.CallbackCache, err = cache.NewRedisCache(redisAddress+":"+redisPort, os.Getenv("REDIS_PASSWORD"), ttl)
+		botClient.CallbackCache, err = cache.NewRedisCache(redisAddress+":"+redisPort, os.Getenv("REDIS_PASSWORD"), ttl)
 		if err != nil {
 			log.Fatalln("Cannot connect to redis:", err)
 		}
 	} else { // Simple in cache memory
-		bot.CallbackCache = cache.NewMemoryCache(5*time.Minute, 10*time.Minute)
+		botClient.CallbackCache = cache.NewMemoryCache(5*time.Minute, 10*time.Minute)
 	}
-	defer bot.CallbackCache.Close()
+	defer botClient.CallbackCache.Close()
 	// Start the reddit oauth
-	bot.RedditOauth, err = reddit.NewRedditOauth(clientID, clientSecret)
+	botClient.RedditOauth, err = reddit.NewRedditOauth(clientID, clientSecret)
 	if err != nil {
 		log.Fatalln("Cannot initialize the reddit oauth:", err.Error())
 	}
-	bot.RunBot(botToken, getAllowedUsers())
+	botClient.RunBot(botToken, getAllowedUsers())
 }
 
 // getAllowedUsers gets the list of users which are allowed to use the bot

--- a/cmd/RedditDownloaderBot/main.go
+++ b/cmd/RedditDownloaderBot/main.go
@@ -19,14 +19,14 @@ func main() {
 	var err error
 	log.Println("Reddit Downloader Bot v" + common.Version)
 	if !util.DoesFfmpegExists() {
-		log.Println("WARNING: ffmpeg is not installed on your system")
+		log.Println("Warning: FFmpeg is not installed on your computer.")
 	}
 	// Load the variables
 	clientID := os.Getenv("CLIENT_ID")
 	clientSecret := os.Getenv("CLIENT_SECRET")
 	botToken := os.Getenv("BOT_TOKEN")
 	if clientID == "" || clientSecret == "" || botToken == "" {
-		log.Fatalln("Please set CLIENT_ID, CLIENT_SECRET and BOT_TOKEN")
+		log.Fatalln("Please set CLIENT_ID, CLIENT_SECRET, and BOT_TOKEN according to the Readme file on GitHub.")
 	}
 	botClient := bot.Client{}
 	// Start up database
@@ -38,7 +38,7 @@ func main() {
 		}
 		botClient.CallbackCache, err = cache.NewRedisCache(redisAddress+":"+redisPort, os.Getenv("REDIS_PASSWORD"), ttl)
 		if err != nil {
-			log.Fatalln("Cannot connect to redis:", err)
+			log.Fatalln("Cannot connect to Redis:", err)
 		}
 	} else { // Simple in cache memory
 		botClient.CallbackCache = cache.NewMemoryCache(5*time.Minute, 10*time.Minute)
@@ -47,7 +47,7 @@ func main() {
 	// Start the reddit oauth
 	botClient.RedditOauth, err = reddit.NewRedditOauth(clientID, clientSecret)
 	if err != nil {
-		log.Fatalln("Cannot initialize the reddit oauth:", err.Error())
+		log.Fatalln("Cannot initialize the Reddit OAuth:", err.Error())
 	}
 	botClient.RunBot(botToken, getAllowedUsers())
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     depends_on:
       - redis
     environment:
-      CLIENT_ID: "1234"
-      CLIENT_SECRET: "4321"
-      BOT_TOKEN: "token"
+      CLIENT_ID: "Reddit client ID"
+      CLIENT_SECRET: "Reddit client secret"
+      BOT_TOKEN: "Telegram bot token"
       REDIS_HOST: redis
       REDIS_PORT: 6379
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module RedditDownloaderBot
 go 1.18
 
 require (
+	github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.28
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/go-faster/errors v0.7.1
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.28 h1:3EidAXUUuDBwaRX5881fmpGGv2WPnW9oHwRMlvdQiwU=
+github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.28/go.mod h1:kL1v4iIjlalwm3gCYGvF4NLa3hs+aKEfRkNJvj4aoDU=
 github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4yPeE=
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
@@ -12,8 +14,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
 github.com/go-faster/errors v0.7.1/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -112,12 +112,12 @@ func (c *Client) fetchPostDetailsAndSend(bot *gotgbot.Bot, ctx *ext.Context) err
 		if len(data.Medias) == 1 && data.Type != reddit.FetchResultMediaTypePhoto {
 			switch data.Type {
 			case reddit.FetchResultMediaTypeGif:
-				return handleGifUpload(bot, data.Medias[0].Link, data.Title, data.ThumbnailLink, realPostUrl, ctx.EffectiveChat.Id)
+				return c.handleGifUpload(bot, data.Medias[0].Link, data.Title, data.ThumbnailLink, realPostUrl, ctx.EffectiveChat.Id)
 			case reddit.FetchResultMediaTypeVideo:
 				// If the video does have an audio, ask user if they want the audio
 				if _, hasAudio := data.HasAudio(); !hasAudio {
 					// Otherwise, just download the video
-					return handleVideoUpload(bot, data.Medias[0].Link, "", data.Title, data.ThumbnailLink, realPostUrl, data.Duration, ctx.EffectiveChat.Id)
+					return c.handleVideoUpload(bot, data.Medias[0].Link, "", data.Title, data.ThumbnailLink, realPostUrl, data.Duration, ctx.EffectiveChat.Id)
 				}
 			default:
 				panic("Shash")
@@ -210,7 +210,7 @@ func (c *Client) handleCallback(bot *gotgbot.Bot, ctx *ext.Context) error {
 		var album reddit.FetchResultAlbum
 		album, err = c.CallbackCache.GetAndDeleteAlbumCache(data.ID)
 		if err == nil {
-			return handleAlbumUpload(bot, album, ctx.EffectiveChat.Id, data.Mode == CallbackButtonDataModeFile)
+			return c.handleAlbumUpload(bot, album, ctx.EffectiveChat.Id, data.Mode == CallbackButtonDataModeFile)
 		} else if errors.Is(err, cache.NotFoundErr) {
 			// It does not exist...
 			_, err = ctx.EffectiveChat.SendMessage(bot, "Please resend the link.", nil)
@@ -233,15 +233,15 @@ func (c *Client) handleCallback(bot *gotgbot.Bot, ctx *ext.Context) error {
 	// Check the media type
 	switch cachedData.Type {
 	case reddit.FetchResultMediaTypeGif:
-		return handleGifUpload(bot, link, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, ctx.EffectiveChat.Id)
+		return c.handleGifUpload(bot, link, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, ctx.EffectiveChat.Id)
 	case reddit.FetchResultMediaTypePhoto:
-		return handlePhotoUpload(bot, link, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, ctx.EffectiveChat.Id, data.Mode == CallbackButtonDataModePhoto)
+		return c.handlePhotoUpload(bot, link, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, ctx.EffectiveChat.Id, data.Mode == CallbackButtonDataModePhoto)
 	case reddit.FetchResultMediaTypeVideo:
 		if data.LinkKey == cachedData.AudioIndex {
-			return handleAudioUpload(bot, link, cachedData.Title, cachedData.PostLink, cachedData.Duration, ctx.EffectiveChat.Id)
+			return c.handleAudioUpload(bot, link, cachedData.Title, cachedData.PostLink, cachedData.Duration, ctx.EffectiveChat.Id)
 		} else {
 			audioURL := cachedData.Links[cachedData.AudioIndex]
-			return handleVideoUpload(bot, link, audioURL, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, cachedData.Duration, ctx.EffectiveChat.Id)
+			return c.handleVideoUpload(bot, link, audioURL, cachedData.Title, cachedData.ThumbnailLink, cachedData.PostLink, cachedData.Duration, ctx.EffectiveChat.Id)
 		}
 	}
 	// What

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -46,7 +46,7 @@ func (c *Client) RunBot(token string, allowedUsers AllowedUsers) {
 		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 60,
 			RequestOpts: &gotgbot.RequestOpts{
-				Timeout: time.Second * 10,
+				Timeout: time.Second * 60,
 			},
 		},
 	})

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -72,7 +72,7 @@ func (c *Client) handleMessage(bot *gotgbot.Bot, ctx *ext.Context) error {
 		_, err := ctx.EffectiveChat.SendMessage(bot, "Hey!\n\nJust send me a post or comment, and I’ll download it for you.", nil)
 		return err
 	case "/about":
-		_, err := ctx.EffectiveChat.SendMessage(bot, "Reddit Downloader Bot v"+common.Version+"\nBy Hirbod Behnam\nSource: https://github.com/mcsaeid/RedditDownloaderBot", nil)
+		_, err := ctx.EffectiveChat.SendMessage(bot, "Reddit Downloader Bot v"+common.Version+"\nBy Hirbod Behnam\nSource: https://github.com/HirbodBehnam/RedditDownloaderBot", nil)
 		return err
 	case "/help":
 		_, err := ctx.EffectiveChat.SendMessage(bot, "You can send me Reddit posts or comments. If it’s text only, I’ll send a text message. If it’s an image or video, I’ll upload and send the content along with the title and link.", nil)

--- a/internal/bot/shared.go
+++ b/internal/bot/shared.go
@@ -1,22 +1,8 @@
 package bot
 
-import (
-	"RedditDownloaderBot/internal/cache"
-	"RedditDownloaderBot/pkg/reddit"
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-)
-
-// CallbackCache is used to cache the data of the callback queries
-var CallbackCache cache.Interface
-var bot *tgbotapi.BotAPI
-var RedditOauth *reddit.Oauth
-
 const RegularMaxUploadSize = 50 * 1000 * 1000 // these must be 1000 not 1024
 const PhotoMaxUploadSize = 10 * 1000 * 1000
 
 // NoThumbnailNeededSize is the size which files bigger than it need a thumbnail
 // Otherwise the telegram will show them without one
 const NoThumbnailNeededSize = 10 * 1000 * 1000
-
-// MarkdownV2 is the styling format used in telegram messages
-const MarkdownV2 = "MarkdownV2"

--- a/internal/bot/types.go
+++ b/internal/bot/types.go
@@ -1,5 +1,16 @@
 package bot
 
+import (
+	"RedditDownloaderBot/internal/cache"
+	"RedditDownloaderBot/pkg/reddit"
+)
+
+// Client is the contains the data needed to operate the bot
+type Client struct {
+	CallbackCache cache.Interface
+	RedditOauth   *reddit.Oauth
+}
+
 // AllowedUsers is a list of users which can use the bot
 // An empty list means that everyone can use the bot
 type AllowedUsers []int64

--- a/internal/bot/uploader.go
+++ b/internal/bot/uploader.go
@@ -3,36 +3,36 @@ package bot
 import (
 	"RedditDownloaderBot/pkg/reddit"
 	"RedditDownloaderBot/pkg/util"
+	"github.com/PaulSonOfLars/gotgbot/v2"
 	"log"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 // handleGifUpload downloads a gif and then uploads it to Telegram
-func handleGifUpload(gifUrl, title, thumbnailUrl, postUrl string, chatID int64) {
+func handleGifUpload(bot *gotgbot.Bot, gifUrl, title, thumbnailUrl, postUrl string, chatID int64) error {
 	// Inform the user we are doing some shit
-	stopReportChannel := statusReporter(chatID, "upload_video")
+	stopReportChannel := statusReporter(bot, chatID, "upload_video")
 	defer close(stopReportChannel)
 	// Download the gif
 	tmpFile, err := reddit.DownloadGif(gifUrl)
 	if err != nil {
 		log.Println("Cannot download file", gifUrl, ":", err)
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot download file.\nHere is the link to file: "+gifUrl))
-		return
+		_, err = bot.SendMessage(chatID, "Cannot download file.\nHere is the link to file: "+gifUrl, nil)
+		return err
 	}
 	defer func() { // Cleanup
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
 	}()
 	// Upload the gif
 	// Check file size
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		bot.Send(tgbotapi.NewMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to file: "+gifUrl))
-		return
+		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to file: "+gifUrl, nil)
+		return err
 	}
 	// Check thumbnail
 	var tmpThumbnailFile *os.File = nil
@@ -40,50 +40,51 @@ func handleGifUpload(gifUrl, title, thumbnailUrl, postUrl string, chatID int64) 
 		tmpThumbnailFile, err = reddit.DownloadThumbnail(thumbnailUrl)
 		if err == nil {
 			defer func() {
-				tmpThumbnailFile.Close()
-				os.Remove(tmpThumbnailFile.Name())
+				_ = tmpThumbnailFile.Close()
+				_ = os.Remove(tmpThumbnailFile.Name())
 			}()
 		}
 	}
 	// Upload it
-	msg := tgbotapi.NewAnimation(chatID, telegramUploadOsFile{tmpFile})
-	msg.Caption = addLinkIfNeeded(escapeMarkdown(title), postUrl)
-	msg.ParseMode = MarkdownV2
+	animationOpt := &gotgbot.SendAnimationOpts{
+		Caption:   addLinkIfNeeded(escapeMarkdown(title), postUrl),
+		ParseMode: gotgbot.ParseModeMarkdownV2,
+	}
 	if tmpThumbnailFile != nil {
-		msg.Thumb = telegramUploadOsFile{tmpThumbnailFile}
+		animationOpt.Thumbnail = fileReaderFromOsFile(tmpThumbnailFile)
 	}
-	_, err = bot.Send(msg)
+	_, err = bot.SendAnimation(chatID, fileReaderFromOsFile(tmpFile), animationOpt)
 	if err != nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot upload file.\nHere is the link to file: "+gifUrl))
 		log.Println("Cannot upload file:", err)
-		return
+		_, err = bot.SendMessage(chatID, "Cannot upload file.\nHere is the link to file: "+gifUrl, nil)
 	}
+	return err
 }
 
 // handleVideoUpload downloads a video and then uploads it to Telegram
-func handleVideoUpload(vidUrl, audioUrl, title, thumbnailUrl, postUrl string, duration int, chatID int64) {
+func handleVideoUpload(bot *gotgbot.Bot, vidUrl, audioUrl, title, thumbnailUrl, postUrl string, duration, chatID int64) error {
 	// Inform the user we are doing some shit
-	stopReportChannel := statusReporter(chatID, "upload_video")
+	stopReportChannel := statusReporter(bot, chatID, "upload_video")
 	defer close(stopReportChannel)
 	// Download the gif
 	tmpFile, err := reddit.DownloadVideo(vidUrl, audioUrl)
 	if err != nil {
 		if errors.Is(err, reddit.FileTooBigError) {
-			bot.Send(tgbotapi.NewMessage(chatID, "Can't download file due to big size.\n"+generateVideoUrlsMessage(vidUrl, audioUrl)))
+			_, err = bot.SendMessage(chatID, "Can't download file due to big size.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 		} else {
 			log.Println("Cannot download file", vidUrl, ":", err)
-			bot.Send(tgbotapi.NewMessage(chatID, "Can't download file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl)))
+			_, err = bot.SendMessage(chatID, "Can't download file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 		}
-		return
+		return err
 	}
 	defer func() { // Cleanup
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
 	}()
 	// Check file size
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		bot.Send(tgbotapi.NewMessage(chatID, "This file is too big to upload it on telegram!\n"+generateVideoUrlsMessage(vidUrl, audioUrl)))
-		return
+		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
+		return err
 	}
 	// Check thumbnail
 	var tmpThumbnailFile *os.File = nil
@@ -91,160 +92,149 @@ func handleVideoUpload(vidUrl, audioUrl, title, thumbnailUrl, postUrl string, du
 		tmpThumbnailFile, err = reddit.DownloadThumbnail(thumbnailUrl)
 		if err == nil {
 			defer func() {
-				tmpThumbnailFile.Close()
-				os.Remove(tmpThumbnailFile.Name())
+				_ = tmpThumbnailFile.Close()
+				_ = os.Remove(tmpThumbnailFile.Name())
 			}()
 		}
 	}
 	// Upload it
-	msg := tgbotapi.NewVideo(chatID, telegramUploadOsFile{tmpFile})
-	msg.Caption = addLinkIfNeeded(escapeMarkdown(title), postUrl)
-	msg.Duration = duration
-	msg.SupportsStreaming = true
-	msg.ParseMode = MarkdownV2
-	if tmpThumbnailFile != nil {
-		msg.Thumb = telegramUploadOsFile{tmpThumbnailFile}
+	videoOpt := &gotgbot.SendVideoOpts{
+		Duration:          duration,
+		Caption:           addLinkIfNeeded(escapeMarkdown(title), postUrl),
+		ParseMode:         gotgbot.ParseModeMarkdownV2,
+		SupportsStreaming: true,
 	}
-	_, err = bot.Send(msg)
+	if tmpThumbnailFile != nil {
+		videoOpt.Thumbnail = fileReaderFromOsFile(tmpThumbnailFile)
+	}
+	_, err = bot.SendVideo(chatID, fileReaderFromOsFile(tmpFile), videoOpt)
 	if err != nil {
 		log.Println("Cannot upload file:", err)
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot upload file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl)))
-		return
+		_, err = bot.SendMessage(chatID, "Cannot upload file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 	}
+	return err
 }
 
 // handleVideoUpload downloads a photo and then uploads it to Telegram
-func handlePhotoUpload(photoUrl, title, thumbnailUrl, postUrl string, chatID int64, asPhoto bool) {
+func handlePhotoUpload(bot *gotgbot.Bot, photoUrl, title, thumbnailUrl, postUrl string, chatID int64, asPhoto bool) error {
 	// Inform the user we are doing some shit
 	var stopReportChannel chan struct{}
 	if asPhoto {
-		stopReportChannel = statusReporter(chatID, "upload_photo")
+		stopReportChannel = statusReporter(bot, chatID, "upload_photo")
 	} else {
-		stopReportChannel = statusReporter(chatID, "upload_document")
+		stopReportChannel = statusReporter(bot, chatID, "upload_document")
 	}
 	defer close(stopReportChannel)
 	// Download the gif
 	tmpFile, err := reddit.DownloadPhoto(photoUrl)
 	if err != nil {
 		log.Println("Cannot download file", photoUrl, ":", err)
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot download file.\nHere is the link to file: "+photoUrl))
-		return
+		_, err = bot.SendMessage(chatID, "Cannot download file.\nHere is the link to file: "+photoUrl, nil)
+		return err
 	}
 	defer func() { // Cleanup
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
 	}()
 	// Check filesize
 	if asPhoto {
 		asPhoto = util.CheckFileSize(tmpFile.Name(), PhotoMaxUploadSize) // send photo as file if it is larger than 10MB
 	}
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		bot.Send(tgbotapi.NewMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to image: "+photoUrl))
-		return
+		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to image: "+photoUrl, nil)
+		return err
 	}
 	// Download thumbnail
 	var tmpThumbnailFile *os.File = nil
-	if !util.CheckFileSize(tmpFile.Name(), NoThumbnailNeededSize) && thumbnailUrl != "" {
+	if !asPhoto && !util.CheckFileSize(tmpFile.Name(), NoThumbnailNeededSize) && thumbnailUrl != "" {
+		// photos does not support thumbnail...
 		tmpThumbnailFile, err = reddit.DownloadThumbnail(thumbnailUrl)
 		if err == nil {
 			defer func() {
-				tmpThumbnailFile.Close()
-				os.Remove(tmpThumbnailFile.Name())
+				_ = tmpThumbnailFile.Close()
+				_ = os.Remove(tmpThumbnailFile.Name())
 			}()
 		}
 	}
 	// Upload
-	var msg tgbotapi.Chattable
 	if asPhoto {
-		photo := tgbotapi.NewPhoto(chatID, telegramUploadOsFile{tmpFile})
-		photo.Caption = addLinkIfNeeded(escapeMarkdown(title), postUrl)
-		photo.ParseMode = MarkdownV2
-		if tmpThumbnailFile != nil {
-			photo.Thumb = telegramUploadOsFile{tmpThumbnailFile}
-		}
-		msg = photo
+		_, err = bot.SendPhoto(chatID, fileReaderFromOsFile(tmpFile), &gotgbot.SendPhotoOpts{
+			Caption:   addLinkIfNeeded(escapeMarkdown(title), postUrl),
+			ParseMode: gotgbot.ParseModeMarkdownV2,
+		})
 	} else {
-		photo := tgbotapi.NewDocument(chatID, telegramUploadOsFile{tmpFile})
-		photo.Caption = addLinkIfNeeded(escapeMarkdown(title), postUrl)
-		photo.ParseMode = MarkdownV2
-		if tmpThumbnailFile != nil {
-			photo.Thumb = telegramUploadOsFile{tmpThumbnailFile}
+		documentOpt := &gotgbot.SendDocumentOpts{
+			Caption:   addLinkIfNeeded(escapeMarkdown(title), postUrl),
+			ParseMode: gotgbot.ParseModeMarkdownV2,
 		}
-		msg = photo
+		if tmpThumbnailFile != nil {
+			documentOpt.Thumbnail = fileReaderFromOsFile(tmpThumbnailFile)
+		}
+		_, err = bot.SendDocument(chatID, fileReaderFromOsFile(tmpFile), documentOpt)
 	}
-	_, err = bot.Send(msg)
 	if err != nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot upload file.\nHere is the link to image: "+photoUrl))
 		log.Println("Cannot upload file:", err)
-		return
+		_, err = bot.SendMessage(chatID, "Cannot upload file.\nHere is the link to image: "+photoUrl, nil)
 	}
+	return err
 }
 
 // handleAlbumUpload uploads an album to Telegram
-func handleAlbumUpload(album reddit.FetchResultAlbum, chatID int64, asFile bool) {
+func handleAlbumUpload(bot *gotgbot.Bot, album reddit.FetchResultAlbum, chatID int64, asFile bool) error {
 	// Report status
-	stopReportChannel := statusReporter(chatID, "upload_photo")
+	stopReportChannel := statusReporter(bot, chatID, "upload_photo")
 	defer close(stopReportChannel)
 	// Download each file of album
 	var err error
 	filePaths := make([]*os.File, 0, len(album.Album))
 	defer func() { // cleanup
 		for _, f := range filePaths {
-			f.Close()
-			os.Remove(f.Name())
+			_ = f.Close()
+			_ = os.Remove(f.Name())
 		}
 	}()
-	fileConfigs := make([]interface{}, 0, len(album.Album))
+	fileConfigs := make([]gotgbot.InputMedia, 0, len(album.Album))
 	fileLinks := make([]string, 0, len(album.Album))
 	for _, media := range album.Album {
 		var tmpFile *os.File
 		var link string
-		var f interface{}
+		var f gotgbot.InputMedia
 		switch media.Type {
 		case reddit.FetchResultMediaTypePhoto:
 			tmpFile, err = reddit.DownloadPhoto(media.Link)
 			if err == nil {
 				if asFile {
-					uploadFile := tgbotapi.NewInputMediaDocument(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					f = uploadFile
+					f = gotgbot.InputMediaDocument{Media: fileReaderFromOsFile(tmpFile), Caption: media.Caption}
 				} else {
-					uploadFile := tgbotapi.NewInputMediaPhoto(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					f = uploadFile
+					f = gotgbot.InputMediaPhoto{Media: fileReaderFromOsFile(tmpFile), Caption: media.Caption}
 				}
 			}
 		case reddit.FetchResultMediaTypeGif:
 			tmpFile, err = reddit.DownloadGif(media.Link)
 			if err == nil {
 				if asFile {
-					uploadFile := tgbotapi.NewInputMediaDocument(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					f = uploadFile
+					f = gotgbot.InputMediaDocument{Media: fileReaderFromOsFile(tmpFile), Caption: media.Caption}
 				} else {
-					uploadFile := tgbotapi.NewInputMediaVideo(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					f = uploadFile
+					f = gotgbot.InputMediaVideo{Media: fileReaderFromOsFile(tmpFile), Caption: media.Caption}
 				}
 			}
 		case reddit.FetchResultMediaTypeVideo:
 			tmpFile, err = reddit.DownloadVideo(media.Link, "") // TODO: can i do something about audio URL?
 			if err == nil {
 				if asFile {
-					uploadFile := tgbotapi.NewInputMediaDocument(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					f = uploadFile
+					f = gotgbot.InputMediaDocument{Media: fileReaderFromOsFile(tmpFile), Caption: media.Caption}
 				} else {
-					uploadFile := tgbotapi.NewInputMediaVideo(telegramUploadOsFile{tmpFile})
-					uploadFile.Caption = media.Caption
-					uploadFile.SupportsStreaming = true
-					f = uploadFile
+					f = gotgbot.InputMediaVideo{
+						Media:             fileReaderFromOsFile(tmpFile),
+						Caption:           media.Caption,
+						SupportsStreaming: true,
+					}
 				}
 			}
 		}
 		if err != nil {
-			log.Println("cannot download media of gallery:", err)
-			bot.Send(tgbotapi.NewMessage(chatID, "Cannot download gallery media; The link was: "+link))
+			log.Println("Cannot download media of gallery:", err)
+			_, _ = bot.SendMessage(chatID, "Cannot download gallery media; The link was: "+link, nil)
 			continue
 		}
 		fileConfigs = append(fileConfigs, f)
@@ -255,77 +245,82 @@ func handleAlbumUpload(album reddit.FetchResultAlbum, chatID int64, asFile bool)
 	// Now upload 10 of them at once
 	i := 0
 	for ; i < len(fileConfigs)/10; i++ {
-		_, err = bot.SendMediaGroup(tgbotapi.NewMediaGroup(chatID, fileConfigs[i*10:(i+1)*10]))
+		_, err = bot.SendMediaGroup(chatID, fileConfigs[i*10:(i+1)*10], nil)
 		if err != nil {
 			log.Println("Cannot upload gallery:", err)
-			bot.Send(tgbotapi.NewMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:(i+1)*10])))
+			_, _ = bot.SendMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:(i+1)*10]), nil)
 		}
 	}
 	err = nil // needed for last error check
 	fileConfigs = fileConfigs[i*10:]
 	if len(fileConfigs) == 1 {
 		switch f := fileConfigs[0].(type) {
-		case tgbotapi.InputMediaPhoto:
-			_, err = bot.Send(tgbotapi.NewPhoto(chatID, f.Media))
-		case tgbotapi.InputMediaVideo:
-			_, err = bot.Send(tgbotapi.NewVideo(chatID, f.Media))
-		case tgbotapi.InputMediaDocument:
-			_, err = bot.Send(tgbotapi.NewDocument(chatID, f.Media))
+		case gotgbot.InputMediaPhoto:
+			_, err = bot.SendPhoto(chatID, f.Media, nil)
+		case gotgbot.InputMediaVideo:
+			_, err = bot.SendVideo(chatID, f.Media, nil)
+		case gotgbot.InputMediaDocument:
+			_, err = bot.SendDocument(chatID, f.Media, nil)
+		default:
+			panic("IMPOSSIBLE")
 		}
 	} else if len(fileConfigs) > 1 {
-		_, err = bot.SendMediaGroup(tgbotapi.NewMediaGroup(chatID, fileConfigs))
+		_, err = bot.SendMediaGroup(chatID, fileConfigs, nil)
 	}
 	if err != nil {
-		log.Println("cannot upload gallery:", err)
-		bot.Send(tgbotapi.NewMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:])))
+		log.Println("Cannot upload gallery:", err)
+		_, err = bot.SendMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:]), nil)
 	}
+	return err
 }
 
 // handleAudioUpload simply downloads then uploads an audio to Telegram
-func handleAudioUpload(audioURL, title, postUrl string, duration int, chatID int64) {
+func handleAudioUpload(bot *gotgbot.Bot, audioURL, title, postUrl string, duration, chatID int64) error {
 	// Send status
-	stopReportChannel := statusReporter(chatID, "upload_voice")
+	stopReportChannel := statusReporter(bot, chatID, "upload_voice")
 	defer close(stopReportChannel)
 	// Create a temp file
 	audioFile, err := reddit.DownloadAudio(audioURL)
 	if err != nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot download audio; "+generateAudioURLMessage(audioURL)))
-		return
+		_, err = bot.SendMessage(chatID, "Cannot download audio; "+generateAudioURLMessage(audioURL), nil)
+		return err
 	}
 	defer func() {
-		audioFile.Close()
-		os.Remove(audioFile.Name())
+		_ = audioFile.Close()
+		_ = os.Remove(audioFile.Name())
 	}()
 	// Simply upload it to telegram
-	msg := tgbotapi.NewAudio(chatID, telegramUploadOsFile{audioFile})
-	msg.Caption = addLinkIfNeeded(escapeMarkdown(title), postUrl)
-	msg.ParseMode = MarkdownV2
-	msg.Duration = duration
-	_, err = bot.Send(msg)
+	_, err = bot.SendAudio(chatID, fileReaderFromOsFile(audioFile), &gotgbot.SendAudioOpts{
+		Caption:   addLinkIfNeeded(escapeMarkdown(title), postUrl),
+		ParseMode: gotgbot.ParseModeMarkdownV2,
+		Duration:  duration,
+	})
 	if err != nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "Cannot upload audio; "+generateAudioURLMessage(audioURL)))
-		return
+		log.Println("Cannot upload audio:", err)
+		_, err = bot.SendMessage(chatID, "Cannot upload audio; "+generateAudioURLMessage(audioURL), nil)
 	}
+	return err
 }
 
 // statusReporter starts reporting for uploading a thing in telegram
 // This function returns a channel which a message must be sent to it when reporting must be stopped
-// You can also close the channel to stop the reporter
-func statusReporter(chatID int64, action string) chan struct{} {
+// You can also close the channel to stop the reporter.
+//
+// TODO: later after the next release of the bot, use ChatAction... types
+func statusReporter(bot *gotgbot.Bot, chatID int64, action string) chan struct{} {
 	doneChan := make(chan struct{}, 1)
-	go statusReporterGoroutine(chatID, action, doneChan)
+	go statusReporterGoroutine(bot, chatID, action, doneChan)
 	return doneChan
 }
 
 // statusReporterGoroutine must be called from another goroutine to report the status of upload
-func statusReporterGoroutine(chatID int64, action string, done <-chan struct{}) {
+func statusReporterGoroutine(bot *gotgbot.Bot, chatID int64, action string, done <-chan struct{}) {
 	ticker := time.NewTicker(time.Second * 5) // we have to send it each 5 seconds
-	actionObject := tgbotapi.NewChatAction(chatID, action)
-	bot.Send(actionObject)
+	_, _ = bot.SendChatAction(chatID, action, nil)
 	for {
 		select {
 		case <-ticker.C:
-			bot.Send(actionObject)
+			_, _ = bot.SendChatAction(chatID, action, nil)
 		case <-done:
 			ticker.Stop()
 			return

--- a/internal/bot/uploader.go
+++ b/internal/bot/uploader.go
@@ -20,8 +20,8 @@ func handleGifUpload(bot *gotgbot.Bot, gifUrl, title, thumbnailUrl, postUrl stri
 	// Download the gif
 	tmpFile, err := reddit.DownloadGif(gifUrl)
 	if err != nil {
-		log.Println("Cannot download file", gifUrl, ":", err)
-		_, err = bot.SendMessage(chatID, "Cannot download file.\nHere is the link to file: "+gifUrl, nil)
+		log.Println("Unable to download", gifUrl, ":", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t download this GIF.\nHere is the link: "+gifUrl, nil)
 		return err
 	}
 	defer func() { // Cleanup
@@ -31,7 +31,7 @@ func handleGifUpload(bot *gotgbot.Bot, gifUrl, title, thumbnailUrl, postUrl stri
 	// Upload the gif
 	// Check file size
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to file: "+gifUrl, nil)
+		_, err = bot.SendMessage(chatID, "The file is too large to upload on Telegram.\nHere is the link: "+gifUrl, nil)
 		return err
 	}
 	// Check thumbnail
@@ -55,8 +55,8 @@ func handleGifUpload(bot *gotgbot.Bot, gifUrl, title, thumbnailUrl, postUrl stri
 	}
 	_, err = bot.SendAnimation(chatID, fileReaderFromOsFile(tmpFile), animationOpt)
 	if err != nil {
-		log.Println("Cannot upload file:", err)
-		_, err = bot.SendMessage(chatID, "Cannot upload file.\nHere is the link to file: "+gifUrl, nil)
+		log.Println("Unable to upload:", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t upload this GIF.\nHere is the link: "+gifUrl, nil)
 	}
 	return err
 }
@@ -70,10 +70,10 @@ func handleVideoUpload(bot *gotgbot.Bot, vidUrl, audioUrl, title, thumbnailUrl, 
 	tmpFile, err := reddit.DownloadVideo(vidUrl, audioUrl)
 	if err != nil {
 		if errors.Is(err, reddit.FileTooBigError) {
-			_, err = bot.SendMessage(chatID, "Can't download file due to big size.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
+			_, err = bot.SendMessage(chatID, "I couldn’t download this file because it’s too large.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 		} else {
-			log.Println("Cannot download file", vidUrl, ":", err)
-			_, err = bot.SendMessage(chatID, "Can't download file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
+			log.Println("Unable to download", vidUrl, ":", err)
+			_, err = bot.SendMessage(chatID, "I couldn’t download this video.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 		}
 		return err
 	}
@@ -83,7 +83,7 @@ func handleVideoUpload(bot *gotgbot.Bot, vidUrl, audioUrl, title, thumbnailUrl, 
 	}()
 	// Check file size
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
+		_, err = bot.SendMessage(chatID, "This file is too large to upload on Telegram.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 		return err
 	}
 	// Check thumbnail
@@ -109,8 +109,8 @@ func handleVideoUpload(bot *gotgbot.Bot, vidUrl, audioUrl, title, thumbnailUrl, 
 	}
 	_, err = bot.SendVideo(chatID, fileReaderFromOsFile(tmpFile), videoOpt)
 	if err != nil {
-		log.Println("Cannot upload file:", err)
-		_, err = bot.SendMessage(chatID, "Cannot upload file.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
+		log.Println("Unable to upload:", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t upload this video.\n"+generateVideoUrlsMessage(vidUrl, audioUrl), nil)
 	}
 	return err
 }
@@ -128,8 +128,8 @@ func handlePhotoUpload(bot *gotgbot.Bot, photoUrl, title, thumbnailUrl, postUrl 
 	// Download the gif
 	tmpFile, err := reddit.DownloadPhoto(photoUrl)
 	if err != nil {
-		log.Println("Cannot download file", photoUrl, ":", err)
-		_, err = bot.SendMessage(chatID, "Cannot download file.\nHere is the link to file: "+photoUrl, nil)
+		log.Println("Unable to download", photoUrl, ":", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t download this image.\nHere is the link: "+photoUrl, nil)
 		return err
 	}
 	defer func() { // Cleanup
@@ -141,7 +141,7 @@ func handlePhotoUpload(bot *gotgbot.Bot, photoUrl, title, thumbnailUrl, postUrl 
 		asPhoto = util.CheckFileSize(tmpFile.Name(), PhotoMaxUploadSize) // send photo as file if it is larger than 10MB
 	}
 	if !util.CheckFileSize(tmpFile.Name(), RegularMaxUploadSize) {
-		_, err = bot.SendMessage(chatID, "This file is too big to upload it on telegram!\nHere is the link to image: "+photoUrl, nil)
+		_, err = bot.SendMessage(chatID, "The file is too large to upload on Telegram.\nHere is the link: "+photoUrl, nil)
 		return err
 	}
 	// Download thumbnail
@@ -173,8 +173,8 @@ func handlePhotoUpload(bot *gotgbot.Bot, photoUrl, title, thumbnailUrl, postUrl 
 		_, err = bot.SendDocument(chatID, fileReaderFromOsFile(tmpFile), documentOpt)
 	}
 	if err != nil {
-		log.Println("Cannot upload file:", err)
-		_, err = bot.SendMessage(chatID, "Cannot upload file.\nHere is the link to image: "+photoUrl, nil)
+		log.Println("Unable to upload:", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t upload this image.\nHere is the link: "+photoUrl, nil)
 	}
 	return err
 }
@@ -233,8 +233,8 @@ func handleAlbumUpload(bot *gotgbot.Bot, album reddit.FetchResultAlbum, chatID i
 			}
 		}
 		if err != nil {
-			log.Println("Cannot download media of gallery:", err)
-			_, _ = bot.SendMessage(chatID, "Cannot download gallery media; The link was: "+link, nil)
+			log.Println("Unable to download:", err)
+			_, _ = bot.SendMessage(chatID, "I couldn’t download the gallery./nHere is the link: "+link, nil)
 			continue
 		}
 		fileConfigs = append(fileConfigs, f)
@@ -247,7 +247,7 @@ func handleAlbumUpload(bot *gotgbot.Bot, album reddit.FetchResultAlbum, chatID i
 	for ; i < len(fileConfigs)/10; i++ {
 		_, err = bot.SendMediaGroup(chatID, fileConfigs[i*10:(i+1)*10], nil)
 		if err != nil {
-			log.Println("Cannot upload gallery:", err)
+			log.Println("Unable to upload:", err)
 			_, _ = bot.SendMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:(i+1)*10]), nil)
 		}
 	}
@@ -268,7 +268,7 @@ func handleAlbumUpload(bot *gotgbot.Bot, album reddit.FetchResultAlbum, chatID i
 		_, err = bot.SendMediaGroup(chatID, fileConfigs, nil)
 	}
 	if err != nil {
-		log.Println("Cannot upload gallery:", err)
+		log.Println("Unable to upload:", err)
 		_, err = bot.SendMessage(chatID, generateGalleryFailedMessage(fileLinks[i*10:]), nil)
 	}
 	return err
@@ -282,7 +282,8 @@ func handleAudioUpload(bot *gotgbot.Bot, audioURL, title, postUrl string, durati
 	// Create a temp file
 	audioFile, err := reddit.DownloadAudio(audioURL)
 	if err != nil {
-		_, err = bot.SendMessage(chatID, "Cannot download audio; "+generateAudioURLMessage(audioURL), nil)
+		log.Println("Unable to download:", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t download the audio.\n"+generateAudioURLMessage(audioURL), nil)
 		return err
 	}
 	defer func() {
@@ -296,8 +297,8 @@ func handleAudioUpload(bot *gotgbot.Bot, audioURL, title, postUrl string, durati
 		Duration:  duration,
 	})
 	if err != nil {
-		log.Println("Cannot upload audio:", err)
-		_, err = bot.SendMessage(chatID, "Cannot upload audio; "+generateAudioURLMessage(audioURL), nil)
+		log.Println("Unable to upload:", err)
+		_, err = bot.SendMessage(chatID, "I couldn’t upload the audio.\n"+generateAudioURLMessage(audioURL), nil)
 	}
 	return err
 }
@@ -333,7 +334,7 @@ func statusReporterGoroutine(bot *gotgbot.Bot, chatID int64, action string, done
 func generateVideoUrlsMessage(videoUrl, audioUrl string) string {
 	var sb strings.Builder
 	sb.Grow(150)
-	sb.WriteString("Here is the link to video file: ")
+	sb.WriteString("Here is the link to the video file: ")
 	sb.WriteString(videoUrl)
 	if audioUrl != "" {
 		sb.WriteString("\n")
@@ -344,7 +345,7 @@ func generateVideoUrlsMessage(videoUrl, audioUrl string) string {
 
 // generateAudioURLMessage generates a text to send to user when downloading an audio fails
 func generateAudioURLMessage(audioURL string) string {
-	return "Here is the link to audio file: " + audioURL
+	return "Here is the link to the audio file: " + audioURL
 }
 
 // generateGalleryFailedMessage generates an error message to send to user when uploading gallery goes wrong
@@ -352,7 +353,7 @@ func generateAudioURLMessage(audioURL string) string {
 func generateGalleryFailedMessage(medias []string) string {
 	var sb strings.Builder
 	sb.Grow(len(medias) * 120) // each link length I guess
-	sb.WriteString("Cannot upload gallery.\nHere are the links of the files:")
+	sb.WriteString("I couldn’t upload the media.\nHere are the links to the files:")
 	for _, media := range medias {
 		sb.WriteByte('\n')
 		sb.WriteString(media)

--- a/internal/bot/uploader.go
+++ b/internal/bot/uploader.go
@@ -45,10 +45,18 @@ func handleGifUpload(bot *gotgbot.Bot, gifUrl, title, thumbnailUrl, postUrl stri
 			}()
 		}
 	}
+	// Check dimension
+	dimensions, err := reddit.GetVideoDimensions(tmpFile.Name())
+	if err != nil {
+		log.Println("Cannot get dimensions:", err)
+	}
+	log.Println(dimensions)
 	// Upload it
 	animationOpt := &gotgbot.SendAnimationOpts{
 		Caption:   addLinkIfNeeded(escapeMarkdown(title), postUrl),
 		ParseMode: gotgbot.ParseModeMarkdownV2,
+		Width:     dimensions.Width,
+		Height:    dimensions.Height,
 	}
 	if tmpThumbnailFile != nil {
 		animationOpt.Thumbnail = fileReaderFromOsFile(tmpThumbnailFile)
@@ -97,12 +105,19 @@ func handleVideoUpload(bot *gotgbot.Bot, vidUrl, audioUrl, title, thumbnailUrl, 
 			}()
 		}
 	}
+	// Check dimension
+	dimensions, err := reddit.GetVideoDimensions(tmpFile.Name())
+	if err != nil {
+		log.Println("Cannot get dimensions:", err)
+	}
 	// Upload it
 	videoOpt := &gotgbot.SendVideoOpts{
 		Duration:          duration,
 		Caption:           addLinkIfNeeded(escapeMarkdown(title), postUrl),
 		ParseMode:         gotgbot.ParseModeMarkdownV2,
 		SupportsStreaming: true,
+		Width:             dimensions.Width,
+		Height:            dimensions.Height,
 	}
 	if tmpThumbnailFile != nil {
 		videoOpt.Thumbnail = fileReaderFromOsFile(tmpThumbnailFile)

--- a/internal/bot/util.go
+++ b/internal/bot/util.go
@@ -3,8 +3,7 @@ package bot
 import (
 	"RedditDownloaderBot/pkg/reddit"
 	"RedditDownloaderBot/pkg/util"
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	"io"
+	"github.com/PaulSonOfLars/gotgbot/v2"
 	"os"
 	"strings"
 )
@@ -19,29 +18,35 @@ var markdownEscaper = strings.NewReplacer("_", "\\_", "*", "\\*", "[", "\\[", "]
 // createPhotoInlineKeyboard creates inline keyboards to get the quality info of a photo
 // Each row represents a quality and each row has two columns: Send as photo or send as file
 // The id must match the ID in the mediaCache
-func createPhotoInlineKeyboard(id string, medias reddit.FetchResultMedia) tgbotapi.InlineKeyboardMarkup {
-	rows := make([][]tgbotapi.InlineKeyboardButton, len(medias.Medias))
+func createPhotoInlineKeyboard(id string, medias reddit.FetchResultMedia) gotgbot.InlineKeyboardMarkup {
+	rows := make([][]gotgbot.InlineKeyboardButton, len(medias.Medias))
 	for i, media := range medias.Medias {
-		column := make([]tgbotapi.InlineKeyboardButton, 2)
+		column := make([]gotgbot.InlineKeyboardButton, 2)
 		// One button to download as photo
 		info := CallbackButtonData{
 			ID:      id,
 			LinkKey: i,
 			Mode:    CallbackButtonDataModePhoto,
 		}
-		column[0] = tgbotapi.NewInlineKeyboardButtonData("Photo "+media.Quality, info.String())
+		column[0] = gotgbot.InlineKeyboardButton{
+			Text:         "Photo " + media.Quality,
+			CallbackData: info.String(),
+		}
 		// One button to download as file
 		info.Mode = CallbackButtonDataModeFile
-		column[1] = tgbotapi.NewInlineKeyboardButtonData("File "+media.Quality, info.String())
+		column[1] = gotgbot.InlineKeyboardButton{
+			Text:         "File " + media.Quality,
+			CallbackData: info.String(),
+		}
 		// Add to rows
 		rows[i] = column
 	}
-	return tgbotapi.InlineKeyboardMarkup{InlineKeyboard: rows}
+	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // createGifInlineKeyboard creates an inline keyboard for downloading gifs based on given reddit.FetchResultMedia
-func createGifInlineKeyboard(id string, medias reddit.FetchResultMedia) tgbotapi.InlineKeyboardMarkup {
-	rows := make([][]tgbotapi.InlineKeyboardButton, len(medias.Medias))
+func createGifInlineKeyboard(id string, medias reddit.FetchResultMedia) gotgbot.InlineKeyboardMarkup {
+	rows := make([][]gotgbot.InlineKeyboardButton, len(medias.Medias))
 	for i, media := range medias.Medias {
 		// One button to download as gif only
 		// They don't support the file format
@@ -50,14 +55,17 @@ func createGifInlineKeyboard(id string, medias reddit.FetchResultMedia) tgbotapi
 			LinkKey: i,
 		}
 		// Add to rows
-		rows[i] = []tgbotapi.InlineKeyboardButton{tgbotapi.NewInlineKeyboardButtonData("Gif "+media.Quality, info.String())}
+		rows[i] = []gotgbot.InlineKeyboardButton{{
+			Text:         "Gif " + media.Quality,
+			CallbackData: info.String(),
+		}}
 	}
-	return tgbotapi.InlineKeyboardMarkup{InlineKeyboard: rows}
+	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // createVideoInlineKeyboard creates an inline keyboard for downloading gifs based on given reddit.FetchResultMedia
-func createVideoInlineKeyboard(id string, medias reddit.FetchResultMedia) tgbotapi.InlineKeyboardMarkup {
-	rows := make([][]tgbotapi.InlineKeyboardButton, len(medias.Medias))
+func createVideoInlineKeyboard(id string, medias reddit.FetchResultMedia) gotgbot.InlineKeyboardMarkup {
+	rows := make([][]gotgbot.InlineKeyboardButton, len(medias.Medias))
 	for i, media := range medias.Medias {
 		// One button to download as gif only
 		// They don't support the file format
@@ -66,9 +74,12 @@ func createVideoInlineKeyboard(id string, medias reddit.FetchResultMedia) tgbota
 			LinkKey: i,
 		}
 		// Add to rows
-		rows[i] = []tgbotapi.InlineKeyboardButton{tgbotapi.NewInlineKeyboardButtonData(media.Quality, info.String())}
+		rows[i] = []gotgbot.InlineKeyboardButton{{
+			Text:         media.Quality,
+			CallbackData: info.String(),
+		}}
 	}
-	return tgbotapi.InlineKeyboardMarkup{InlineKeyboard: rows}
+	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // Adds the link of the post to a text if needed (the INCLUDE_LINK is set)
@@ -84,29 +95,7 @@ func escapeMarkdown(text string) string {
 	return markdownEscaper.Replace(text)
 }
 
-// telegramUploadOsFile is wrapper for os.File in order to make it uploadable in Telegram
-type telegramUploadOsFile struct {
-	*os.File
-}
-
-func (f telegramUploadOsFile) NeedsUpload() bool {
-	return true
-}
-
-func (f telegramUploadOsFile) UploadData() (string, io.Reader, error) {
-	// Move the file pointer to beginning
-	_, err := f.Seek(0, io.SeekStart)
-	if err != nil {
-		return "", nil, err
-	}
-	// Note: I can use io.NopCloser in order to make the bot not close the file
-	s, err := f.Stat()
-	if err != nil {
-		return "", nil, err
-	}
-	return s.Name(), f, nil
-}
-
-func (f telegramUploadOsFile) SendData() string {
-	panic("telegramUploadOsFile must be uploaded")
+// Create a gotgbot.FileReader from a os.File
+func fileReaderFromOsFile(file *os.File) *gotgbot.FileReader {
+	return &gotgbot.FileReader{Name: file.Name(), Data: file}
 }

--- a/internal/bot/util.go
+++ b/internal/bot/util.go
@@ -57,7 +57,7 @@ func createGifInlineKeyboard(id string, medias reddit.FetchResultMedia) gotgbot.
 		}
 		// Add to rows
 		rows[i] = []gotgbot.InlineKeyboardButton{{
-			Text:         "Gif " + media.Quality,
+			Text:         "GIF " + media.Quality,
 			CallbackData: info.String(),
 		}}
 	}

--- a/internal/bot/util.go
+++ b/internal/bot/util.go
@@ -4,6 +4,7 @@ import (
 	"RedditDownloaderBot/pkg/reddit"
 	"RedditDownloaderBot/pkg/util"
 	"github.com/PaulSonOfLars/gotgbot/v2"
+	"io"
 	"os"
 	"strings"
 )
@@ -97,5 +98,14 @@ func escapeMarkdown(text string) string {
 
 // Create a gotgbot.FileReader from a os.File
 func fileReaderFromOsFile(file *os.File) *gotgbot.FileReader {
-	return &gotgbot.FileReader{Name: file.Name(), Data: file}
+	// Move the file pointer to beginning
+	_, err := file.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil
+	}
+	s, err := file.Stat()
+	if err != nil {
+		return nil
+	}
+	return &gotgbot.FileReader{Name: s.Name(), Data: file}
 }

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -75,12 +75,12 @@ func parseRedisJson[T any](val string, err error) (T, error) {
 	if err == redis.Nil {
 		return result, NotFoundErr
 	} else if err != nil {
-		return result, errors.Wrap(err, "cannot get data from redis")
+		return result, errors.Wrap(err, "Unable to fetch data from Redis")
 	}
 	// Parse the json
 	err = json.NewDecoder(strings.NewReader(val)).Decode(&result)
 	if err != nil {
-		return result, errors.Wrap(err, "cannot parse json")
+		return result, errors.Wrap(err, "Unable to parse JSON")
 	}
 	return result, nil
 }

--- a/internal/cache/types.go
+++ b/internal/cache/types.go
@@ -17,7 +17,7 @@ type CallbackDataCached struct {
 	// If there is no audio, this must be -1
 	AudioIndex int
 	// The duration of video
-	Duration int
+	Duration int64
 	// What media is this
 	Type reddit.FetchResultMediaType
 }

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is the version of this program :|
-const Version = "3.2.1"
+const Version = "4.0.0-alpha"
 
 // GlobalHttpClient is a http client which all request must be done through it
 var GlobalHttpClient = &http.Client{

--- a/pkg/reddit/downloader.go
+++ b/pkg/reddit/downloader.go
@@ -18,7 +18,7 @@ const maxDownloadSize = 50 * 1000 * 1000
 
 // FileTooBigError indicates that this file is too big to be uploaded to Telegram
 // So we don't download it at first place
-var FileTooBigError = errors.New("file too big")
+var FileTooBigError = errors.New("The file is too large.")
 
 // DownloadPhoto downloads a photo from reddit and returns the saved file in it
 func DownloadPhoto(link string) (*os.File, error) {
@@ -34,13 +34,13 @@ func DownloadPhoto(link string) (*os.File, error) {
 	// Generate a temp file
 	tmpFile, err := os.CreateTemp("", "*."+fileName)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot create temp file")
+		return nil, errors.Wrap(err, "Unable to create a temporary file")
 	}
 	// Download the file
 	err = downloadToFile(link, tmpFile)
 	if err != nil {
 		os.Remove(tmpFile.Name())
-		return nil, errors.Wrap(err, "cannot download file")
+		return nil, errors.Wrap(err, "Unable to download the file")
 	}
 	// We are good
 	return tmpFile, nil
@@ -52,7 +52,7 @@ func DownloadVideo(vidUrl, audioUrl string) (videoFile *os.File, err error) {
 	// Download the video in a temp file
 	videoFile, err = os.CreateTemp("", "*.mp4")
 	if err != nil {
-		err = errors.Wrap(err, "cannot create a temp file for video")
+		err = errors.Wrap(err, "Unable to create a temporary file for the video")
 		return
 	}
 	defer func() {
@@ -64,14 +64,14 @@ func DownloadVideo(vidUrl, audioUrl string) (videoFile *os.File, err error) {
 	}()
 	err = downloadToFile(vidUrl, videoFile)
 	if err != nil {
-		err = errors.Wrap(err, "cannot download file")
+		err = errors.Wrap(err, "Unable to download the file")
 		return
 	}
 	// Otherwise, search for an audio file
 	hasAudio := audioUrl != ""
 	audFile, err := os.CreateTemp("", "*.mp4")
 	if err != nil {
-		err = errors.Wrap(err, "cannot create a temp file for audio")
+		err = errors.Wrap(err, "Unable to create a temporary file for the audio")
 		return
 	}
 	// We don't need audio file anyway
@@ -95,7 +95,7 @@ func DownloadVideo(vidUrl, audioUrl string) (videoFile *os.File, err error) {
 		// Convert
 		finalFile, err = os.CreateTemp("", "*.mp4")
 		if err != nil {
-			err = errors.Wrap(err, "cannot create a temp file for final video")
+			err = errors.Wrap(err, "Unable to create a temporary file for the converted video")
 			return
 		}
 		cmd := exec.Command("ffmpeg",
@@ -107,7 +107,7 @@ func DownloadVideo(vidUrl, audioUrl string) (videoFile *os.File, err error) {
 		cmd.Stderr = &stderr
 		err = cmd.Run()
 		if err != nil {
-			log.Println("Cannot convert video:", err, "\n", stderr.String())
+			log.Println("Unable to convert the video:", err, "\n", stderr.String())
 			finalFile.Close()
 			os.Remove(finalFile.Name())
 			// We don't return error here
@@ -144,7 +144,7 @@ func DownloadGif(link string) (*os.File, error) {
 func DownloadThumbnail(link string) (*os.File, error) {
 	tmpFile, err := os.CreateTemp("", "*.jpg")
 	if err != nil {
-		log.Println("Cannot create temp file for thumbnail:", err)
+		log.Println("Unable to create a temporary file for the thumbnail:", err)
 		return nil, err
 	}
 	// Download to file
@@ -162,7 +162,7 @@ func DownloadThumbnail(link string) (*os.File, error) {
 func DownloadAudio(audioUrl string) (*os.File, error) {
 	tmpFile, err := os.CreateTemp("", "*.m4a")
 	if err != nil {
-		log.Println("Cannot create temp file for audio:", err)
+		log.Println("Unable to create a temporary file for the audio:", err)
 		return nil, err
 	}
 	// Download to file
@@ -186,10 +186,10 @@ func downloadToFile(link string, f *os.File) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusForbidden {
-		return errors.New("forbidden")
+		return errors.New("Forbidden")
 	}
 	if resp.ContentLength == -1 {
-		return errors.New("unknown length")
+		return errors.New("Unknown length")
 	}
 	if resp.ContentLength > maxDownloadSize {
 		return FileTooBigError

--- a/pkg/reddit/fetch.go
+++ b/pkg/reddit/fetch.go
@@ -219,7 +219,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 	// Check thumbnail; This must be done before checking cross posts
 	thumbnailUrl := ""
 	if t, ok := root["thumbnail"]; ok {
-		thumbnailUrl = t.(string)
+		thumbnailUrl = html.UnescapeString(t.(string))
 		// Check the url; Sometimes, the value of this is default
 		if !util.IsUrl(thumbnailUrl) {
 			thumbnailUrl = ""

--- a/pkg/reddit/fetch.go
+++ b/pkg/reddit/fetch.go
@@ -37,7 +37,7 @@ func (o *Oauth) StartFetch(postUrl string) (fetchResult interface{}, realPostUrl
 		if r := recover(); r != nil {
 			fetchError = &FetchError{
 				NormalError: fmt.Sprintf("Recovering from panic in StartFetch. Error encountered: %v; URL: %v", r, postUrl),
-				BotError: "Unable to get the data.\nMaybe a deleted post or invalid URL?",
+				BotError:    "Unable to get the data.\nMaybe a deleted post or invalid URL?",
 			}
 		}
 	}()
@@ -246,7 +246,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				if strings.HasPrefix(root["url"].(string), "https://i.imgur.com") { // Example: https://www.reddit.com/r/dankmemes/comments/gag117/you_daughter_of_a_bitch_im_in/
 					gifDownloadUrl := root["url"].(string)
 					lastSlash := strings.LastIndex(gifDownloadUrl, "/")
-					gifDownloadUrl = gifDownloadUrl[:lastSlash+1] + "Download" + gifDownloadUrl[lastSlash:]
+					gifDownloadUrl = gifDownloadUrl[:lastSlash+1] + "download" + gifDownloadUrl[lastSlash:]
 					result.Medias = []FetchResultMediaEntry{{
 						Link:    gifDownloadUrl,
 						Quality: "Imgur", // It doesn't matter
@@ -307,7 +307,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 		case "rich:video": // files hosted other than reddit; This bot currently supports Gfycat.com
 			if urlObject, domainExists := root["domain"]; domainExists {
 				switch urlObject.(string) {
-				case "Gfycat.com": // just act like gif
+				case "gfycat.com": // just act like gif
 					images := root["preview"].(map[string]interface{})["images"].([]interface{})[0].(map[string]interface{})
 					if _, hasVariants := images["variants"]; hasVariants {
 						if mp4, hasMp4 := images["variants"].(map[string]interface{})["mp4"]; hasMp4 {

--- a/pkg/reddit/fetch.go
+++ b/pkg/reddit/fetch.go
@@ -301,7 +301,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				Medias:        qualities,
 				ThumbnailLink: thumbnailUrl,
 				Title:         title,
-				Duration:      int(duration),
+				Duration:      int64(duration),
 				Type:          FetchResultMediaTypeVideo,
 			}, nil
 		case "rich:video": // files hosted other than reddit; This bot currently supports gfycat.com

--- a/pkg/reddit/fetch.go
+++ b/pkg/reddit/fetch.go
@@ -36,8 +36,8 @@ func (o *Oauth) StartFetch(postUrl string) (fetchResult interface{}, realPostUrl
 	defer func() {
 		if r := recover(); r != nil {
 			fetchError = &FetchError{
-				NormalError: fmt.Sprintf("recovering from panic in StartFetch error is: %v, The url was: %v", r, postUrl),
-				BotError:    "Cannot get data. (panic)\nMaybe deleted post or invalid url?",
+				NormalError: fmt.Sprintf("Recovering from panic in StartFetch. Error encountered: %v; URL: %v", r, postUrl),
+				BotError: "Unable to get the data.\nMaybe a deleted post or invalid URL?",
 			}
 		}
 	}()
@@ -50,8 +50,8 @@ func (o *Oauth) StartFetch(postUrl string) (fetchResult interface{}, realPostUrl
 		root, err := o.GetComment(postId)
 		if err != nil {
 			return nil, "", &FetchError{
-				NormalError: "cannot download comment: " + err.Error(),
-				BotError:    "Cannot download comment",
+				NormalError: "Unable to fetch the comment: " + err.Error(),
+				BotError:    "Unable to fetch the comment",
 			}
 		}
 		return getCommentFromRoot(root), realPostUrl, nil
@@ -60,8 +60,8 @@ func (o *Oauth) StartFetch(postUrl string) (fetchResult interface{}, realPostUrl
 	root, err := o.GetPost(postId)
 	if err != nil {
 		fetchError = &FetchError{
-			NormalError: "cannot get the post data: " + err.Error(),
-			BotError:    "Cannot get the post data",
+			NormalError: "Unable to get the post data: " + err.Error(),
+			BotError:    "Unable to get the post data",
 		}
 		return
 	}
@@ -106,13 +106,13 @@ func (o *Oauth) getPostID(postUrl string) (postID, realPostUrl string, isComment
 			postUrl = line
 			break
 		}
-		u = nil // this is for last loop. If u is nil after that final loop, it means that there is no reddit url in text
+		u = nil // this is for last loop. If u is nil after that final loop, it means that there is no reddit URL in text
 	}
 	if u == nil {
 		realPostUrl = ""
 		err = &FetchError{
 			NormalError: "",
-			BotError:    "Cannot parse reddit the url. Does your text contain a reddit url?",
+			BotError:    "Unable to parse the URL. Please make sure your message contains a valid Reddit link.",
 		}
 		return
 	}
@@ -123,23 +123,23 @@ func (o *Oauth) getPostID(postUrl string) (postID, realPostUrl string, isComment
 	if len(split) < 5 {
 		err = &FetchError{
 			NormalError: "",
-			BotError:    "Cannot parse reddit the url. Does your text contain a reddit url?",
+			BotError:    "Unable to parse the URL. Please make sure your message contains a valid Reddit link.",
 		}
 		return
 	}
-	if split[3] == "s" { // new shared reddit url like this: https://reddit.com/r/UkraineWarVideoReport/s/AKk56RlMN6
+	if split[3] == "s" { // new shared reddit URL like this: https://reddit.com/r/UkraineWarVideoReport/s/AKk56RlMN6
 		followedUrl, err2 := o.FollowRedirect(u.String())
 		if err2 != nil {
 			err = &FetchError{
-				NormalError: "cannot follow shared link url: " + err2.Error(),
-				BotError:    "Cannot follow the shared link url",
+				NormalError: "Unable to follow the shared URL: " + err2.Error(),
+				BotError:    "Unable to follow the shared URL",
 			}
 			return
 		}
 		if followedUrl == u.String() {
 			err = &FetchError{
-				NormalError: "recursion detected: " + postID,
-				BotError:    "Corrupted link. Paste the link in your browser and send the redirected link to bot.",
+				NormalError: "Recursion detected: " + postID,
+				BotError:    "Corrupted or unsupported URL. Paste the link in your browser, then send the redirected link to the bot.",
 			}
 			return
 		}
@@ -151,7 +151,7 @@ func (o *Oauth) getPostID(postUrl string) (postID, realPostUrl string, isComment
 	return split[4], realPostUrl, false, nil
 }
 
-// getCommentFromRoot gets the comment content from root of the json API.
+// getCommentFromRoot gets the comment content from root of the JSON API.
 // The result is either a FetchResultMedia with gif type or FetchResultComment
 func getCommentFromRoot(root map[string]interface{}) interface{} {
 	// Check gif comments
@@ -160,7 +160,7 @@ func getCommentFromRoot(root map[string]interface{}) interface{} {
 		return FetchResultMedia{
 			Medias: []FetchResultMediaEntry{{
 				Link:    fmt.Sprintf("https://i.giphy.com/media/%s/giphy.gif", matches[1]),
-				Quality: "giphy",
+				Quality: "Giphy",
 			}},
 			Type:  FetchResultMediaTypeGif,
 			Title: strings.ReplaceAll(text, matches[0], ""),
@@ -184,16 +184,16 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 		data, exists := root["data"]
 		if !exists {
 			fetchError = &FetchError{
-				NormalError: "cannot parse the page data: cannot find node `data`",
-				BotError:    "Cannot parse the page data: cannot find node `data`",
+				NormalError: "Unable to parse the page data: couldn’t find node `data`",
+				BotError:    "Unable to parse the page data: couldn’t find node `data`",
 			}
 			return
 		}
 		children, exists := data.(map[string]interface{})["children"]
 		if !exists {
 			fetchError = &FetchError{
-				NormalError: "cannot parse the page data: cannot find node `data->children`",
-				BotError:    "Cannot parse the page data: cannot find node `data->children`",
+				NormalError: "Unable to parse the page data: couldn’t find node `data->children`",
+				BotError:    "Unable to parse the page data: couldn’t find node `data->children`",
 			}
 			return
 		}
@@ -201,8 +201,8 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 		data, exists = data.(map[string]interface{})["data"]
 		if !exists {
 			fetchError = &FetchError{
-				NormalError: "cannot parse the page data: cannot find node `data->children[0]->data`",
-				BotError:    "Cannot parse the page data: cannot find node `data->children[0]->data`",
+				NormalError: "Unable to parse the page data: couldn’t find node `data->children[0]->data`",
+				BotError:    "Unable to parse the page data: couldn’t find node `data->children[0]->data`",
 			}
 			return
 		}
@@ -246,10 +246,10 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				if strings.HasPrefix(root["url"].(string), "https://i.imgur.com") { // Example: https://www.reddit.com/r/dankmemes/comments/gag117/you_daughter_of_a_bitch_im_in/
 					gifDownloadUrl := root["url"].(string)
 					lastSlash := strings.LastIndex(gifDownloadUrl, "/")
-					gifDownloadUrl = gifDownloadUrl[:lastSlash+1] + "download" + gifDownloadUrl[lastSlash:]
+					gifDownloadUrl = gifDownloadUrl[:lastSlash+1] + "Download" + gifDownloadUrl[lastSlash:]
 					result.Medias = []FetchResultMediaEntry{{
 						Link:    gifDownloadUrl,
-						Quality: "imgur", // It doesn't matter
+						Quality: "Imgur", // It doesn't matter
 					}}
 				} else {
 					result.Medias = extractPhotoGifQualities(root["preview"].(map[string]interface{})["images"].([]interface{})[0].(map[string]interface{})["variants"].(map[string]interface{})["mp4"].(map[string]interface{}))
@@ -274,7 +274,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				return FetchResultMedia{
 					Medias: []FetchResultMediaEntry{{
 						Link:    u[:len(u)-4] + "mp4",
-						Quality: "imgur", // It doesn't matter
+						Quality: "Imgur", // It doesn't matter
 					}},
 					ThumbnailLink: thumbnailUrl,
 					Title:         title,
@@ -293,8 +293,8 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 			qualities, err := extractVideoQualities(dashURL)
 			if err != nil {
 				return nil, &FetchError{
-					NormalError: "cannot get qualities for video. The main url was " + postUrl + "; Error was " + err.Error(),
-					BotError:    "Cannot get the video. Here is the direct link to video:\n" + fallbackURL,
+					NormalError: "Unable to get qualities for video. The main URL was " + postUrl + "; Error was " + err.Error(),
+					BotError:    "Unable to get the video. Here is the direct link to video:\n" + fallbackURL,
 				}
 			}
 			return FetchResultMedia{
@@ -304,10 +304,10 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				Duration:      int64(duration),
 				Type:          FetchResultMediaTypeVideo,
 			}, nil
-		case "rich:video": // files hosted other than reddit; This bot currently supports gfycat.com
+		case "rich:video": // files hosted other than reddit; This bot currently supports Gfycat.com
 			if urlObject, domainExists := root["domain"]; domainExists {
 				switch urlObject.(string) {
-				case "gfycat.com": // just act like gif
+				case "Gfycat.com": // just act like gif
 					images := root["preview"].(map[string]interface{})["images"].([]interface{})[0].(map[string]interface{})
 					if _, hasVariants := images["variants"]; hasVariants {
 						if mp4, hasMp4 := images["variants"].(map[string]interface{})["mp4"]; hasMp4 {
@@ -327,8 +327,8 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 							qualities, err := extractVideoQualities(dashURL)
 							if err != nil {
 								return nil, &FetchError{
-									NormalError: "cannot get qualities for gfycat. The main url was " + postUrl + "; Error was " + err.Error(),
-									BotError:    "Cannot get the video. Here is the direct link to gfycat:\n" + fallback,
+									NormalError: "Unable to get the qualities for Gfycat. The original link: " + postUrl + ". Error encountered: " + err.Error(),
+									BotError:    "Unable to get the video.\nHere is the link:" + fallback,
 								}
 							}
 							return FetchResultMedia{
@@ -340,16 +340,16 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 						}
 					}
 					return nil, &FetchError{
-						NormalError: "cannot get the media from gfycat. The main url was " + postUrl,
-						BotError:    "Cannot get the video. Here is the direct link to gfycat:\n" + root["url"].(string),
+						NormalError: "Unable to get the media from Gfycat. The original link: " + postUrl,
+						BotError:    "Unable to get the video.\nHere is the link:" + root["url"].(string),
 					}
 				case "streamable.com": // example: https://streamable.com/u2jzoo
 					// Download the source at first
 					source, err := common.GlobalHttpClient.Get(root["url"].(string))
 					if err != nil {
 						return nil, &FetchError{
-							NormalError: "cannot get the source code of " + root["url"].(string) + ": " + err.Error(),
-							BotError:    "Cannot get the source code of " + root["url"].(string),
+							NormalError: "Unable to get the source code of " + root["url"].(string) + ": " + err.Error(),
+							BotError:    "Unable to get the source code of " + root["url"].(string),
 						}
 					}
 					defer source.Body.Close()
@@ -357,8 +357,8 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 					doc, err := goquery.NewDocumentFromReader(source.Body)
 					if err != nil {
 						return nil, &FetchError{
-							NormalError: "cannot get the parse code of " + root["url"].(string) + ": " + err.Error(),
-							BotError:    "Cannot get the parse code of " + root["url"].(string),
+							NormalError: "Unable to get the parse code of " + root["url"].(string) + ": " + err.Error(),
+							BotError:    "Unable to get the parse code of " + root["url"].(string),
 						}
 					}
 					result := FetchResultMedia{
@@ -377,23 +377,23 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 					})
 					return result, nil
 				case "redgifs.com":
-					// get redgifs info from api
+					// get RedGIFs info from api
 					redgifsid := helpers.GetRedGifsID(root["url"].(string))
 					if redgifsid == "" {
 						return nil, &FetchError{
-							NormalError: "cannot get redgifs id from " + root["url"].(string),
-							BotError:    "Cannot get redgifs id from  " + root["url"].(string),
+							NormalError: "Unable to get RedGIFs ID from " + root["url"].(string),
+							BotError:    "Unable to get RedGIFs ID from  " + root["url"].(string),
 						}
 					}
 
-					// api for redgifs is in https://i.redgifs.com/docs/index.html
+					// api for RedGIFs is in https://i.redgifs.com/docs/index.html
 					infoUrl := fmt.Sprintf("https://api.redgifs.com/v2/gifs/%s", redgifsid)
 
 					source, err := common.GlobalHttpClient.Get(infoUrl)
 					if err != nil {
 						return nil, &FetchError{
-							NormalError: "cannot get redgifs info " + infoUrl + ": " + err.Error(),
-							BotError:    "Cannot get redgifs info " + infoUrl,
+							NormalError: "Unable to get RedGIFs info " + infoUrl + ": " + err.Error(),
+							BotError:    "Unable to get RedGIFs info " + infoUrl,
 						}
 					}
 					defer source.Body.Close()
@@ -401,18 +401,18 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 					doc, err := helpers.GetRedGifsInfo(source.Body)
 					if err != nil {
 						return nil, &FetchError{
-							NormalError: "cannot get the parse redgifs info from " + infoUrl + ": " + err.Error(),
-							BotError:    "Cannot get the parse redgifs info from " + infoUrl,
+							NormalError: "Unable to get the parse RedGIFs info from " + infoUrl + ": " + err.Error(),
+							BotError:    "Unable to get the parse RedGIFs info from " + infoUrl,
 						}
 					}
 					result := FetchResultMedia{
 						Medias: []FetchResultMediaEntry{
 							{
-								Quality: "hd",
+								Quality: "HD",
 								Link:    doc.Gif.Urls.Hd,
 							},
 							{
-								Quality: "sd",
+								Quality: "SD",
 								Link:    doc.Gif.Urls.Sd,
 							},
 						},
@@ -431,7 +431,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 				default:
 					return nil, &FetchError{
 						NormalError: "",
-						BotError:    "This bot does not support downloading from " + urlObject.(string) + "\nThe url field in json is " + root["url"].(string),
+						BotError:    "This bot doesn’t support downloading from " + urlObject.(string) + "\nThe URL field in JSON is " + root["url"].(string),
 					}
 				}
 			} else {
@@ -443,7 +443,7 @@ func getPost(postUrl string, root map[string]interface{}) (fetchResult interface
 		default:
 			return nil, &FetchError{
 				NormalError: "",
-				BotError:    "This post type is not supported: " + hint.(string),
+				BotError:    "This type of post is not supported: " + hint.(string),
 			}
 		}
 	} else { // text or gallery

--- a/pkg/reddit/fetch_test.go
+++ b/pkg/reddit/fetch_test.go
@@ -262,7 +262,7 @@ func TestGetPostId(t *testing.T) {
 			NeedsInternet:     false,
 			ExpectedID:        "",
 			ExpectedIsComment: false,
-			ExpectedError:     "Cannot parse reddit the url. Does your text contain a reddit url?",
+			ExpectedError:     "Unable to parse the URL. Please make sure your message contains a valid Reddit link.",
 		},
 		{
 			TestName:          "Short Url",
@@ -270,7 +270,7 @@ func TestGetPostId(t *testing.T) {
 			NeedsInternet:     false,
 			ExpectedID:        "",
 			ExpectedIsComment: false,
-			ExpectedError:     "Cannot parse reddit the url. Does your text contain a reddit url?",
+			ExpectedError:     "Unable to parse the URL. Please make sure your message contains a valid Reddit link.",
 		},
 		{
 			TestName:          "Short Reddit Url",
@@ -379,7 +379,7 @@ func TestGetCommentFromRoot(t *testing.T) {
 			Expected: FetchResultMedia{
 				Medias: []FetchResultMediaEntry{{
 					Link:    "https://i.giphy.com/media/gVoBC0SuaHStq/giphy.gif",
-					Quality: "giphy",
+					Quality: "Giphy",
 				}},
 				Type:  FetchResultMediaTypeGif,
 				Title: "",
@@ -525,7 +525,7 @@ func TestGetPost(t *testing.T) {
 			ExpectedResult: FetchResultMedia{
 				Medias: []FetchResultMediaEntry{{
 					Link:    "https://i.imgur.com/download/QdBe1Vw.gif",
-					Quality: "imgur",
+					Quality: "Imgur",
 				}},
 				ThumbnailLink: "https://b.thumbs.redditmedia.com/OZVSbT-X1eTPZADOoF4l8ZoYcKC_dWxQ-DTBbdcINLU.jpg",
 				Title:         "You daughter of a bitch, I'm in.",
@@ -569,7 +569,7 @@ func TestGetPost(t *testing.T) {
 			ExpectedResult: nil,
 			ExpectedError: &FetchError{
 				NormalError: "",
-				BotError:    "This bot does not support downloading from youtu.be\nThe url field in json is https://youtu.be/7ILCRfPmQxQ",
+				BotError:    "This bot doesn’t support downloading from youtu.be\nThe URL field in JSON is https://youtu.be/7ILCRfPmQxQ",
 			},
 		},
 		{
@@ -707,7 +707,7 @@ func TestGetPost(t *testing.T) {
 			if test.DashFile.ID != "" {
 				mux := http.NewServeMux()
 				mux.HandleFunc("/"+test.DashFile.ID+"/DASHPlaylist.mpd", func(w http.ResponseWriter, _ *http.Request) {
-					w.Write(test.DashFile.Content)
+					_, _ = w.Write(test.DashFile.Content)
 				})
 				server := httptest.NewServer(mux)
 				defer server.Close()

--- a/pkg/reddit/fetch_test.go
+++ b/pkg/reddit/fetch_test.go
@@ -700,6 +700,40 @@ func TestGetPost(t *testing.T) {
 			}},
 			ExpectedError: nil,
 		},
+		{
+			TestName: "Thumbnail",
+			PostUrl:  "https://www.reddit.com/r/me_irl/comments/1equo0f/me_irl/",
+			Root:     []byte(`{"kind": "Listing", "data": {"after": null, "dist": 1, "modhash": "9aybqvrbai0a9a4fc14dee1cba670a86a8fc5b0e1fd8c3cff9", "geo_filter": "", "children": [{"kind": "t3", "data": {"approved_at_utc": null, "subreddit": "me_irl", "selftext": "Female pheasant wasn't enchanted by his performance, but he hefuses to give up and keeps doing his mating dance . ", "author_fullname": "t2_zy52eab0g", "saved": false, "mod_reason_title": null, "gilded": 0, "clicked": false, "title": "me_irl", "link_flair_richtext": [], "subreddit_name_prefixed": "r/me_irl", "hidden": false, "pwls": 6, "link_flair_css_class": null, "downs": 0, "thumbnail_height": 140, "top_awarded_type": null, "hide_score": false, "name": "t3_1equo0f", "quarantine": false, "link_flair_text_color": "dark", "upvote_ratio": 0.98, "author_flair_background_color": null, "subreddit_type": "public", "ups": 1003, "total_awards_received": 0, "media_embed": {}, "thumbnail_width": 140, "author_flair_template_id": null, "is_original_content": false, "user_reports": [], "secure_media": {"reddit_video": {"bitrate_kbps": 1200, "fallback_url": "https://v.redd.it/617fdb3axbid1/DASH_480.mp4?source=fallback", "has_audio": true, "height": 688, "width": 480, "scrubber_media_url": "https://v.redd.it/617fdb3axbid1/DASH_96.mp4", "dash_url": "https://v.redd.it/617fdb3axbid1/DASHPlaylist.mpd?a=1726148041%2CNjFhNjZjY2U1ZWQ5OTc3MjgzMjA5MjBmMjU1OWEwNTY1MzNkMzUwMjUxMzhmZGE5NjgxYTdhYjA2NDA1YzFiZA%3D%3D&amp;v=1&amp;f=sd", "duration": 23, "hls_url": "https://v.redd.it/617fdb3axbid1/HLSPlaylist.m3u8?a=1726148041%2COGQzMjk4ZDZjNjU0ZGViNWM0OTYxNmQwYjdjZTFmZjhhMjc4ZjBhYmE4NDhlZTVkMjU0YzhlYjM3ZWVlOTkxMA%3D%3D&amp;v=1&amp;f=sd", "is_gif": false, "transcoding_status": "completed"}}, "is_reddit_media_domain": true, "is_meta": false, "category": null, "secure_media_embed": {}, "link_flair_text": null, "can_mod_post": false, "score": 1003, "approved_by": null, "is_created_from_ads_ui": false, "author_premium": false, "thumbnail": "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?width=140&amp;height=140&amp;crop=140:140,smart&amp;format=jpg&amp;v=enabled&amp;lthumb=true&amp;s=9a47bfd51801d34da41a40004c6d5217a3136e6a", "edited": false, "author_flair_css_class": null, "author_flair_richtext": [], "gildings": {}, "post_hint": "hosted:video", "content_categories": null, "is_self": false, "mod_note": null, "created": 1723510398.0, "link_flair_type": "text", "wls": 6, "removed_by_category": null, "banned_by": null, "author_flair_type": "text", "domain": "v.redd.it", "allow_live_comments": false, "selftext_html": "&lt;!-- SC_OFF --&gt;&lt;div class=\"md\"&gt;&lt;p&gt;Female pheasant wasn&amp;#39;t enchanted by his performance, but he hefuses to give up and keeps doing his mating dance . &lt;/p&gt;\n&lt;/div&gt;&lt;!-- SC_ON --&gt;", "likes": true, "suggested_sort": null, "banned_at_utc": null, "url_overridden_by_dest": "https://v.redd.it/617fdb3axbid1", "view_count": null, "archived": false, "no_follow": false, "is_crosspostable": true, "pinned": false, "over_18": false, "preview": {"images": [{"source": {"url": "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?format=pjpg&amp;auto=webp&amp;s=892d3a60ccd4d1a602637f0ffb974645fe1cea09", "width": 480, "height": 688}, "resolutions": [{"url": "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?width=108&amp;crop=smart&amp;format=pjpg&amp;auto=webp&amp;s=22ac39cc4f2bdd67116162c394bebc2874d4fe12", "width": 108, "height": 154}, {"url": "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?width=216&amp;crop=smart&amp;format=pjpg&amp;auto=webp&amp;s=2a9950deba37336669de14f1a7de42427afd560d", "width": 216, "height": 309}, {"url": "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?width=320&amp;crop=smart&amp;format=pjpg&amp;auto=webp&amp;s=d3867b893511c0659c4cd169013e3aead0a424e4", "width": 320, "height": 458}], "variants": {}, "id": "eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm"}], "enabled": false}, "all_awardings": [], "awarders": [], "media_only": false, "can_gild": false, "spoiler": false, "locked": false, "author_flair_text": null, "treatment_tags": [], "visited": false, "removed_by": null, "num_reports": null, "distinguished": null, "subreddit_id": "t5_2vegg", "author_is_blocked": false, "mod_reason_by": null, "removal_reason": null, "link_flair_background_color": "", "id": "1equo0f", "is_robot_indexable": true, "report_reasons": null, "author": "CuteGrayRhino", "discussion_type": null, "num_comments": 40, "send_replies": true, "whitelist_status": "all_ads", "contest_mode": false, "mod_reports": [], "author_patreon_flair": false, "author_flair_text_color": null, "permalink": "/r/me_irl/comments/1equo0f/me_irl/", "parent_whitelist_status": "all_ads", "stickied": false, "url": "https://v.redd.it/617fdb3axbid1", "subreddit_subscribers": 7627403, "created_utc": 1723510398.0, "num_crossposts": 0, "media": {"reddit_video": {"bitrate_kbps": 1200, "fallback_url": "https://v.redd.it/617fdb3axbid1/DASH_480.mp4?source=fallback", "has_audio": true, "height": 688, "width": 480, "scrubber_media_url": "https://v.redd.it/617fdb3axbid1/DASH_96.mp4", "dash_url": "https://v.redd.it/617fdb3axbid1/DASHPlaylist.mpd?a=1726148041%2CNjFhNjZjY2U1ZWQ5OTc3MjgzMjA5MjBmMjU1OWEwNTY1MzNkMzUwMjUxMzhmZGE5NjgxYTdhYjA2NDA1YzFiZA%3D%3D&amp;v=1&amp;f=sd", "duration": 23, "hls_url": "https://v.redd.it/617fdb3axbid1/HLSPlaylist.m3u8?a=1726148041%2COGQzMjk4ZDZjNjU0ZGViNWM0OTYxNmQwYjdjZTFmZjhhMjc4ZjBhYmE4NDhlZTVkMjU0YzhlYjM3ZWVlOTkxMA%3D%3D&amp;v=1&amp;f=sd", "is_gif": false, "transcoding_status": "completed"}}, "is_video": true}}], "before": null}}`),
+			ExpectedResult: FetchResultMedia{
+				Medias: FetchResultMediaEntries{
+					FetchResultMediaEntry{
+						Link:    "https://v.redd.it/617fdb3axbid1/DASH_480.mp4",
+						Quality: "480p",
+					},
+					FetchResultMediaEntry{
+						Link:    "https://v.redd.it/617fdb3axbid1/DASH_360.mp4",
+						Quality: "360p",
+					},
+					FetchResultMediaEntry{
+						Link:    "https://v.redd.it/617fdb3axbid1/DASH_270.mp4",
+						Quality: "270p",
+					},
+					FetchResultMediaEntry{
+						Link:    "https://v.redd.it/617fdb3axbid1/DASH_220.mp4",
+						Quality: "220p",
+					},
+					FetchResultMediaEntry{
+						Link:    "https://v.redd.it/617fdb3axbid1/DASH_AUDIO_128.mp4",
+						Quality: "Audio",
+					},
+				},
+				ThumbnailLink: "https://external-preview.redd.it/eHhsa3JrdDl4YmlkMYG42k61zUHLZWYmXgKxVFtbkqT2ytev2qoJoAjMPjdm.png?width=140&height=140&crop=140:140,smart&format=jpg&v=enabled&lthumb=true&s=9a47bfd51801d34da41a40004c6d5217a3136e6a",
+				Title:         "me_irl",
+				Duration:      23,
+				Type:          FetchResultMediaTypeVideo,
+			},
+			ExpectedError: nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.TestName, func(t *testing.T) {

--- a/pkg/reddit/types.go
+++ b/pkg/reddit/types.go
@@ -111,3 +111,9 @@ type FetchResultAlbumEntry struct {
 type FetchResultAlbum struct {
 	Album []FetchResultAlbumEntry
 }
+
+// Dimension of a media
+type Dimension struct {
+	Width  int64
+	Height int64
+}

--- a/pkg/reddit/types.go
+++ b/pkg/reddit/types.go
@@ -72,7 +72,7 @@ type FetchResultMedia struct {
 	// Title is the title of the post
 	Title string
 	// Duration of the video. This entry does not matter on other types
-	Duration int
+	Duration int64
 	// Types says what kind of media is this
 	Type FetchResultMediaType
 }


### PR DESCRIPTION
The [telegram-bot-api](https://github.com/go-telegram-bot-api/telegram-bot-api) looks dead to me: It hasn't been updated in two years. So I think it's a good time to ditch it. I recently found out [gotgbot](https://github.com/PaulSonOfLars/gotgbot) which uses a code generation schema to generate the types for the bot API based on the official documentation of Telegram Bot API. This means that maintaining its code is VERY easy and from time to time, you probably need to run some scripts to keep it updated. With that in mind, I think it's a very good project and should be used more!

Of course it's a bare bone and low level project because it only implements the types and endpoints of the bot API but for a small bot like this, I think it gets the job done.

I'll have to do more testing before merging tho...